### PR TITLE
Add user option to use JPMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /nbactions.xml
+target
+# IntelliJ IDEA files
+.idea
+raspimaven-archetype.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -9,20 +9,75 @@
 
   <name>raspimaven-archetype</name>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>11</java.version>
+  </properties>
+
   <build>
     <extensions>
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>2.3</version>
+        <version>3.2.0</version>
+<!--        I used this with basic psxcad -> de ce?-->
+<!--        <version>3.0.1</version>-->
       </extension>
     </extensions>
 
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.0.0-M1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.3</version>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+            <addDefaultExcludes>false</addDefaultExcludes>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,17 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
+    <groovy-all-version>3.0.7</groovy-all-version>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>${groovy-all-version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
 
   <build>
     <extensions>
@@ -20,10 +30,35 @@
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
         <version>3.2.0</version>
-<!--        I used this with basic psxcad -> de ce?-->
-<!--        <version>3.0.1</version>-->
       </extension>
     </extensions>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>addSources</goal>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>removeStubs</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sources>
+            <source>
+              <directory>${project.basedir}/src/main/resources/META-INF</directory>
+              <includes>
+                <include>**/*.groovy</include>
+              </includes>
+            </source>
+          </sources>
+        </configuration>
+      </plugin>
+    </plugins>
 
     <pluginManagement>
       <plugins>
@@ -78,6 +113,11 @@
           <configuration>
             <addDefaultExcludes>false</addDefaultExcludes>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.12.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,0 +1,7 @@
+def dir = new File(new File(request.outputDirectory), request.artifactId)
+def useJavaPlatformModuleSystem = request.getProperties().get("useJavaPlatformModuleSystem")
+
+if (useJavaPlatformModuleSystem.toLowerCase() == "false"){
+    println "Deleting module-info.java"
+    assert new File("$dir/src/main/java/module-info.java").delete()
+}

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -11,14 +11,30 @@
 			<defaultValue>Main</defaultValue>
 			<validationRegex/>
 		</requiredProperty>
+		<requiredProperty key="useJavaPlatformModuleSystem" >
+			<defaultValue>true</defaultValue>
+			<validationRegex>^(?i)(true|false)$</validationRegex>
+		</requiredProperty>
 	</requiredProperties>
  
 	<fileSets>
 		<fileSet filtered="true" packaged="true" encoding="UTF-8">
 			<directory>src/main/java</directory>
+			<excludes>
+				<exclude>module-info.java</exclude>
+			</excludes>
 			<includes>
 				<include>**/*.java</include>
 			</includes>
+		</fileSet>
+		<fileSet filtered="true" packaged="false">
+			<directory>src/main/java</directory>
+			<includes>
+				<include>module-info.java</include>
+			</includes>
+		</fileSet>
+		<fileSet filtered="false" packaged="false">
+			<directory>src/main/resources</directory>
 		</fileSet>
 		<fileSet filtered="true" encoding="UTF-8">
 			<directory>antrun</directory>

--- a/src/main/resources/archetype-resources/antrun/build.xml
+++ b/src/main/resources/archetype-resources/antrun/build.xml
@@ -54,6 +54,21 @@
 		<property name="local.dist.jar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}.${symbol_dollar}{project.packaging}"/>
 		<property name="remote.dist.fatjar" value="${symbol_dollar}{remote.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
 		<property name="local.dist.fatjar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
+
+		<fail message="The 'target.run.module.class' property must be set in ${symbol_dollar}{target.platform.filename} if 'run.with.java.module'=true in the 'pom.xml'.">
+			<condition>
+				<and>
+					<equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
+					<not>
+						<isset property="target.run.module.class"/>
+					</not>
+				</and>
+			</condition>
+		</fail>
+
+		<condition property="project.run.cmd" value="-p ${symbol_dollar}{remote.dist.dir}/lib -m ${symbol_dollar}{target.run.module.class}" else="-jar ${symbol_dollar}{remote.dist.jar}">
+			<equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
+		</condition>
 	</target>
 
 	<target name="-check-fatjar" depends="-init">
@@ -108,7 +123,7 @@
 			<sequential>
 				<!--antcall target="profile-rp-calibrate-passwd"/-->
 				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true" usepty="true"
-								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} -jar ${symbol_dollar}{remote.dist.jar} ${symbol_dollar}{remote.application.args}"/>
+								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
 			</sequential>
 		</macrodef>
 		<macrodef name="runwithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
@@ -116,7 +131,7 @@
 			<sequential>
 				<!--antcall target="profile-rp-calibrate-key"/-->
 				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" usepty="true"
-								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} -jar ${symbol_dollar}{remote.dist.jar} ${symbol_dollar}{remote.application.args}"/>
+								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
 			</sequential>
 		</macrodef>
 	</target>

--- a/src/main/resources/archetype-resources/antrun/build.xml
+++ b/src/main/resources/archetype-resources/antrun/build.xml
@@ -3,216 +3,216 @@
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="RemotePlatform" default="default" basedir=".." xmlns:remote="http://www.netbeans.org/ns/j2se-project/remote-platform/1" xmlns:j2seproject1="http://www.netbeans.org/ns/j2se-project/1" xmlns:j2seproject3="http://www.netbeans.org/ns/j2se-project/3">
-	<description></description>
-	<target name="default">
-		<echo message="Default target is not set, you must specify which target you want to run."/>
-	</target>
-		
-	<target name="-init">
-		<property name="remote.run.jvmargs" value=""/>
-		<property name="remote.debug.jvmargs" value=""/>
-		<property name="remote.debug.suspend" value="y"/>
-		<property name="remote.application.args" value=""/>
-		
-		<fail unless="target.platform.name">Remote platform name must be set.</fail>
-		<property name="target.platform.filename" value="./platform/${symbol_dollar}{target.platform.name}.properties"/>
-		<property file="${symbol_dollar}{target.platform.filename}"/>
-		<fail unless="target.platform.host">'target.platform.host' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
-		<fail unless="target.platform.port">'target.platform.port' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
-		<fail unless="target.platform.username">'target.platform.username' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
-		<condition property="remote.platform.auth.passwd">
-			<isset property="target.platform.password"/>
-		</condition>
-		<condition property="remote.platform.auth.key">
-			<and>
-				<not>
-					<isset property="remote.platform.auth.passwd"/>
-				</not>
-				<isset property="target.platform.privatekey"/>
-				<isset property="target.platform.passphrase"/>
-			</and>
-		</condition>
-		<condition property="auth.ok">
-			<or>
-				<isset property="remote.platform.auth.passwd"/>
-				<isset property="remote.platform.auth.key"/>
-			</or>
-		</condition>
-		<condition property="run.mode" value="sudo">
-			<equals arg1="${symbol_dollar}{target.run.as.root}" arg2="true" casesensitive="" />
-		</condition>
-		<property name="run.mode" value=""/>
-		<fail unless="auth.ok">Either 'target.platform.password' or 'target.platform.privatekey' + 'target.platform.passphrase' properties must be set in ${symbol_dollar}{target.platform.filename}.</fail>
-		<fail unless="target.remote.jre">'target.remote.jre' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
-		<fail unless="target.remote.home">'target.remote.home' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
-		<!--basename file="${symbol_dollar}{dist.jar}" property="dist.jar.name"/-->
-		<basename file="${symbol_dollar}{basedir}" property="remote.project.name"/>
-		<property name="remote.project.dir" value="${symbol_dollar}{target.remote.home}/${symbol_dollar}{remote.project.name}"/>
-		<property name="remote.dist.dir" value="${symbol_dollar}{remote.project.dir}/dist"/>
-		<property name="remote.java.executable" value="${symbol_dollar}{target.remote.jre}/bin/java"/>	
-		<property name="remote.dist.jar" value="${symbol_dollar}{remote.dist.dir}/${symbol_dollar}{dist.jar.name}.${symbol_dollar}{project.packaging}"/>
-		<property name="local.dist.jar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}.${symbol_dollar}{project.packaging}"/>
-		<property name="remote.dist.fatjar" value="${symbol_dollar}{remote.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
-		<property name="local.dist.fatjar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
+    <description></description>
+    <target name="default">
+        <echo message="Default target is not set, you must specify which target you want to run."/>
+    </target>
 
-		<fail message="The 'target.run.module.class' property must be set in ${symbol_dollar}{target.platform.filename} if 'run.with.java.module'=true in the 'pom.xml'.">
-			<condition>
-				<and>
-					<equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
-					<not>
-						<isset property="target.run.module.class"/>
-					</not>
-				</and>
-			</condition>
-		</fail>
+    <target name="-init">
+        <property name="remote.run.jvmargs" value=""/>
+        <property name="remote.debug.jvmargs" value=""/>
+        <property name="remote.debug.suspend" value="y"/>
+        <property name="remote.application.args" value=""/>
+        
+        <fail unless="target.platform.name">Remote platform name must be set.</fail>
+        <property name="target.platform.filename" value="./platform/${symbol_dollar}{target.platform.name}.properties"/>
+        <property file="${symbol_dollar}{target.platform.filename}"/>
+        <fail unless="target.platform.host">'target.platform.host' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
+        <fail unless="target.platform.port">'target.platform.port' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
+        <fail unless="target.platform.username">'target.platform.username' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
+        <condition property="remote.platform.auth.passwd">
+            <isset property="target.platform.password"/>
+        </condition>
+        <condition property="remote.platform.auth.key">
+            <and>
+                <not>
+                    <isset property="remote.platform.auth.passwd"/>
+                </not>
+                <isset property="target.platform.privatekey"/>
+                <isset property="target.platform.passphrase"/>
+            </and>
+        </condition>
+        <condition property="auth.ok">
+            <or>
+                <isset property="remote.platform.auth.passwd"/>
+                <isset property="remote.platform.auth.key"/>
+            </or>
+        </condition>
+        <condition property="run.mode" value="sudo">
+            <equals arg1="${symbol_dollar}{target.run.as.root}" arg2="true" casesensitive="" />
+        </condition>
+        <property name="run.mode" value=""/>
+        <fail unless="auth.ok">Either 'target.platform.password' or 'target.platform.privatekey' + 'target.platform.passphrase' properties must be set in ${symbol_dollar}{target.platform.filename}.</fail>
+        <fail unless="target.remote.jre">'target.remote.jre' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
+        <fail unless="target.remote.home">'target.remote.home' property is missing in ${symbol_dollar}{target.platform.filename}.</fail>
+        <!--basename file="${symbol_dollar}{dist.jar}" property="dist.jar.name"/-->
+        <basename file="${symbol_dollar}{basedir}" property="remote.project.name"/>
+        <property name="remote.project.dir" value="${symbol_dollar}{target.remote.home}/${symbol_dollar}{remote.project.name}"/>
+        <property name="remote.dist.dir" value="${symbol_dollar}{remote.project.dir}/dist"/>
+        <property name="remote.java.executable" value="${symbol_dollar}{target.remote.jre}/bin/java"/>    
+        <property name="remote.dist.jar" value="${symbol_dollar}{remote.dist.dir}/${symbol_dollar}{dist.jar.name}.${symbol_dollar}{project.packaging}"/>
+        <property name="local.dist.jar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}.${symbol_dollar}{project.packaging}"/>
+        <property name="remote.dist.fatjar" value="${symbol_dollar}{remote.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
+        <property name="local.dist.fatjar" value="${symbol_dollar}{local.dist.dir}/${symbol_dollar}{dist.jar.name}-jar-with-dependencies.${symbol_dollar}{project.packaging}"/>
 
-		<condition property="project.run.cmd" value="-p ${symbol_dollar}{remote.dist.dir}/lib -m ${symbol_dollar}{target.run.module.class}" else="-jar ${symbol_dollar}{remote.dist.jar}">
-			<equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
-		</condition>
-	</target>
+        <fail message="The 'target.run.module.class' property must be set in ${symbol_dollar}{target.platform.filename} if 'run.with.java.module'=true in the 'pom.xml'.">
+            <condition>
+                <and>
+                    <equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
+                    <not>
+                        <isset property="target.run.module.class"/>
+                    </not>
+                </and>
+            </condition>
+        </fail>
 
-	<target name="-check-fatjar" depends="-init">
-		<available file="${symbol_dollar}{local.dist.fatjar}" property="fatjar.exist"/>
-	</target>
-	
-	<target name="-rename-fatjar" depends="-check-fatjar" if="fatjar.exist">
-		<move file="${symbol_dollar}{local.dist.fatjar}" tofile="${symbol_dollar}{local.dist.jar}"/>
-	</target>
-	
-	<target name="-declare-macros" depends="-rename-fatjar">
-		<macrodef name="cleanwithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<sequential>
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" 
-								 password="${symbol_dollar}{target.platform.password}" trust="true" 
-								 command="cd '${symbol_dollar}{remote.dist.dir}'; rm -rf *.jar lib/*.jar"/>
-			</sequential>
-		</macrodef>
-		<macrodef name="cleanwithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<sequential>
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}"
-								 keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" 
-								 command="cd '${symbol_dollar}{remote.dist.dir}'; rm -rf *.jar lib/*.jar"/>
-			</sequential>
-		</macrodef>
-		<macrodef name="copywithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<attribute name="additionaljvmargs" default=""/>
-			<sequential>
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true" command="mkdir -p '${symbol_dollar}{remote.dist.dir}'"/>
-				<scp todir="${symbol_dollar}{target.platform.username}@${symbol_dollar}{target.platform.host}:${symbol_dollar}{remote.dist.dir}" port="${symbol_dollar}{target.platform.port}" password="${symbol_dollar}{target.platform.password}" trust="true">
-					<fileset dir="${symbol_dollar}{local.dist.dir}">
-						<include name="*.${symbol_dollar}{project.packaging}"/>
-						<include name="lib/*.${symbol_dollar}{project.packaging}"/>
-					</fileset>
-				</scp>
-			</sequential>
-		</macrodef>
-		<macrodef name="copywithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<attribute name="additionaljvmargs" default=""/>
-			<sequential>
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" command="mkdir -p '${symbol_dollar}{remote.dist.dir}'"/>
-				<scp todir="${symbol_dollar}{target.platform.username}@${symbol_dollar}{target.platform.host}:${symbol_dollar}{remote.dist.dir}" port="${symbol_dollar}{target.platform.port}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true">
-					<fileset dir="${symbol_dollar}{local.dist.dir}">
-						<include name="*.${symbol_dollar}{project.packaging}"/>
-						<include name="lib/*.${symbol_dollar}{project.packaging}"/>
-					</fileset>
-				</scp>
-			</sequential>
-		</macrodef>
-		<macrodef name="runwithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<attribute name="additionaljvmargs" default=""/>
-			<sequential>
-				<!--antcall target="profile-rp-calibrate-passwd"/-->
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true" usepty="true"
-								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
-			</sequential>
-		</macrodef>
-		<macrodef name="runwithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
-			<attribute name="additionaljvmargs" default=""/>
-			<sequential>
-				<!--antcall target="profile-rp-calibrate-key"/-->
-				<sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" usepty="true"
-								 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
-			</sequential>
-		</macrodef>
-	</target>
-		
-	<target name="-ask-password" unless="target.platform.password" if="remote.platform.auth.passwd">
-		<input message="Password ${symbol_dollar}{target.platform.user}@${symbol_dollar}{target.platform.host}:" addproperty="target.platform.password">
-			<handler type="secure"/>
-		</input>
-	</target>
+        <condition property="project.run.cmd" value="-p ${symbol_dollar}{remote.dist.dir}/lib -m ${symbol_dollar}{target.run.module.class}" else="-jar ${symbol_dollar}{remote.dist.jar}">
+            <equals arg1="${symbol_dollar}{target.run.as.module}" arg2="true" casesensitive="" />
+        </condition>
+    </target>
 
-	<target name="-ask-passphrase" unless="target.platform.passphrase" if="remote.platform.auth.key">
-		<input message="Passphrase ${symbol_dollar}{target.platform.user}@${symbol_dollar}{target.platform.host}:" addproperty="target.platform.passphrase">
-			<handler type="secure"/>
-		</input>
-	</target>
-
-	<target name="-check-vm-debug" depends="-init">
-		<condition property="remote.debug.available" value="true">
-			<or>
-				<istrue value="${symbol_dollar}{target.debug.supported}"/>
-			</or>
-		</condition>
-		<fail unless="remote.debug.available" message="The Runtime JVM ${symbol_dollar}{target.platform.host} does not support debugging."/>
-	</target>
-
-	<target name="-copy-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
-		<remote:copywithpasswd/>
-	</target>
-		
-	<target name="-copy-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
-		<remote:copywithkey/>
-	</target>
-
-	<target name="-run-remote-passwd" depends="-init, -declare-macros, -ask-password, -copy-remote-passwd" if="remote.platform.auth.passwd">
-		<remote:runwithpasswd/>
-	</target>
-		
-	<target name="-run-remote-key" depends="-init, -declare-macros, -ask-passphrase, -copy-remote-key" if="remote.platform.auth.key">
-		<remote:runwithkey/>
-	</target>
-
-	<target name="-clean-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
-		<remote:cleanwithpasswd/>
-	</target>
-		
-	<target name="-clean-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
-		<remote:cleanwithkey/>
-	</target>
-
-	<target name="-debug-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
-		<sshsession host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true">
-			<remotetunnel lport="${symbol_dollar}{target.debug.port}" lhost="localhost" rport="${symbol_dollar}{target.debug.port}"/>
-			<sequential>
-				<remote:runwithpasswd additionaljvmargs="${symbol_dollar}{remote.debug.jvmargs} -agentlib:jdwp=transport=dt_socket,server=y,suspend=${symbol_dollar}{remote.debug.suspend},address=${symbol_dollar}{target.platform.host}:${symbol_dollar}{target.debug.port}"/>
-			</sequential>
-		</sshsession>
-	</target>
-
-	<target name="-debug-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
-		<sshsession host="${symbol_dollar}{remote.platform.host}" port="${symbol_dollar}{remote.platform.port}" username="${symbol_dollar}{remote.platform.username}" keyfile="${symbol_dollar}{remote.platform.keyfile}" passphrase="${symbol_dollar}{remote.platform.passphrase}" trust="true">
-			<remotetunnel lport="${symbol_dollar}{target.debug.port}" lhost="localhost" rport="${symbol_dollar}{target.debug.port}"/>
-			<sequential>
-				<remote:runwithkey additionaljvmargs="${symbol_dollar}{remote.debug.jvmargs} -agentlib:jdwp=transport=dt_socket,server=y,suspend=${symbol_dollar}{remote.debug.suspend},address=${symbol_dollar}{target.platform.host}:${symbol_dollar}{target.debug.port}"/>
-			</sequential>
-		</sshsession>
-	</target>
+    <target name="-check-fatjar" depends="-init">
+        <available file="${symbol_dollar}{local.dist.fatjar}" property="fatjar.exist"/>
+    </target>
     
-	<target name="build-remote" depends="-copy-remote-passwd, -copy-remote-key">
-		
-	</target>
-	
-	<target name="run-remote" depends="-run-remote-passwd, -run-remote-key">
-		
-	</target>
+    <target name="-rename-fatjar" depends="-check-fatjar" if="fatjar.exist">
+        <move file="${symbol_dollar}{local.dist.fatjar}" tofile="${symbol_dollar}{local.dist.jar}"/>
+    </target>
+    
+    <target name="-declare-macros" depends="-rename-fatjar">
+        <macrodef name="cleanwithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <sequential>
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" 
+                                 password="${symbol_dollar}{target.platform.password}" trust="true" 
+                                 command="cd '${symbol_dollar}{remote.dist.dir}'; rm -rf *.jar lib/*.jar"/>
+            </sequential>
+        </macrodef>
+        <macrodef name="cleanwithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <sequential>
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}"
+                                 keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" 
+                                 command="cd '${symbol_dollar}{remote.dist.dir}'; rm -rf *.jar lib/*.jar"/>
+            </sequential>
+        </macrodef>
+        <macrodef name="copywithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <attribute name="additionaljvmargs" default=""/>
+            <sequential>
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true" command="mkdir -p '${symbol_dollar}{remote.dist.dir}'"/>
+                <scp todir="${symbol_dollar}{target.platform.username}@${symbol_dollar}{target.platform.host}:${symbol_dollar}{remote.dist.dir}" port="${symbol_dollar}{target.platform.port}" password="${symbol_dollar}{target.platform.password}" trust="true">
+                    <fileset dir="${symbol_dollar}{local.dist.dir}">
+                        <include name="*.${symbol_dollar}{project.packaging}"/>
+                        <include name="lib/*.${symbol_dollar}{project.packaging}"/>
+                    </fileset>
+                </scp>
+            </sequential>
+        </macrodef>
+        <macrodef name="copywithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <attribute name="additionaljvmargs" default=""/>
+            <sequential>
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" command="mkdir -p '${symbol_dollar}{remote.dist.dir}'"/>
+                <scp todir="${symbol_dollar}{target.platform.username}@${symbol_dollar}{target.platform.host}:${symbol_dollar}{remote.dist.dir}" port="${symbol_dollar}{target.platform.port}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true">
+                    <fileset dir="${symbol_dollar}{local.dist.dir}">
+                        <include name="*.${symbol_dollar}{project.packaging}"/>
+                        <include name="lib/*.${symbol_dollar}{project.packaging}"/>
+                    </fileset>
+                </scp>
+            </sequential>
+        </macrodef>
+        <macrodef name="runwithpasswd" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <attribute name="additionaljvmargs" default=""/>
+            <sequential>
+                <!--antcall target="profile-rp-calibrate-passwd"/-->
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true" usepty="true"
+                                 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
+            </sequential>
+        </macrodef>
+        <macrodef name="runwithkey" uri="http://www.netbeans.org/ns/j2se-project/remote-platform/1">
+            <attribute name="additionaljvmargs" default=""/>
+            <sequential>
+                <!--antcall target="profile-rp-calibrate-key"/-->
+                <sshexec host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" keyfile="${symbol_dollar}{target.platform.privatekey}" passphrase="${symbol_dollar}{target.platform.passphrase}" trust="true" usepty="true"
+                                 command="cd '${symbol_dollar}{remote.project.dir}'; ${symbol_dollar}{run.mode} '${symbol_dollar}{remote.java.executable}' @{additionaljvmargs} -Dfile.encoding=${symbol_dollar}{remote.runtime.encoding} ${symbol_dollar}{remote.run.jvmargs} ${symbol_dollar}{project.run.cmd} ${symbol_dollar}{remote.application.args}"/>
+            </sequential>
+        </macrodef>
+    </target>
+        
+    <target name="-ask-password" unless="target.platform.password" if="remote.platform.auth.passwd">
+        <input message="Password ${symbol_dollar}{target.platform.user}@${symbol_dollar}{target.platform.host}:" addproperty="target.platform.password">
+            <handler type="secure"/>
+        </input>
+    </target>
 
-	<target name="clean-remote" depends="-clean-remote-passwd, -clean-remote-key">
-		
-	</target>
+    <target name="-ask-passphrase" unless="target.platform.passphrase" if="remote.platform.auth.key">
+        <input message="Passphrase ${symbol_dollar}{target.platform.user}@${symbol_dollar}{target.platform.host}:" addproperty="target.platform.passphrase">
+            <handler type="secure"/>
+        </input>
+    </target>
 
-	<target name="debug-remote" depends="-debug-remote-passwd, -debug-remote-key">
-		
-	</target>
+    <target name="-check-vm-debug" depends="-init">
+        <condition property="remote.debug.available" value="true">
+            <or>
+                <istrue value="${symbol_dollar}{target.debug.supported}"/>
+            </or>
+        </condition>
+        <fail unless="remote.debug.available" message="The Runtime JVM ${symbol_dollar}{target.platform.host} does not support debugging."/>
+    </target>
+
+    <target name="-copy-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
+        <remote:copywithpasswd/>
+    </target>
+        
+    <target name="-copy-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
+        <remote:copywithkey/>
+    </target>
+
+    <target name="-run-remote-passwd" depends="-init, -declare-macros, -ask-password, -copy-remote-passwd" if="remote.platform.auth.passwd">
+        <remote:runwithpasswd/>
+    </target>
+        
+    <target name="-run-remote-key" depends="-init, -declare-macros, -ask-passphrase, -copy-remote-key" if="remote.platform.auth.key">
+        <remote:runwithkey/>
+    </target>
+
+    <target name="-clean-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
+        <remote:cleanwithpasswd/>
+    </target>
+        
+    <target name="-clean-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
+        <remote:cleanwithkey/>
+    </target>
+
+    <target name="-debug-remote-passwd" depends="-init, -declare-macros, -ask-password" if="remote.platform.auth.passwd">
+        <sshsession host="${symbol_dollar}{target.platform.host}" port="${symbol_dollar}{target.platform.port}" username="${symbol_dollar}{target.platform.username}" password="${symbol_dollar}{target.platform.password}" trust="true">
+            <remotetunnel lport="${symbol_dollar}{target.debug.port}" lhost="localhost" rport="${symbol_dollar}{target.debug.port}"/>
+            <sequential>
+                <remote:runwithpasswd additionaljvmargs="${symbol_dollar}{remote.debug.jvmargs} -agentlib:jdwp=transport=dt_socket,server=y,suspend=${symbol_dollar}{remote.debug.suspend},address=${symbol_dollar}{target.platform.host}:${symbol_dollar}{target.debug.port}"/>
+            </sequential>
+        </sshsession>
+    </target>
+
+    <target name="-debug-remote-key" depends="-init, -declare-macros, -ask-passphrase" if="remote.platform.auth.key">
+        <sshsession host="${symbol_dollar}{remote.platform.host}" port="${symbol_dollar}{remote.platform.port}" username="${symbol_dollar}{remote.platform.username}" keyfile="${symbol_dollar}{remote.platform.keyfile}" passphrase="${symbol_dollar}{remote.platform.passphrase}" trust="true">
+            <remotetunnel lport="${symbol_dollar}{target.debug.port}" lhost="localhost" rport="${symbol_dollar}{target.debug.port}"/>
+            <sequential>
+                <remote:runwithkey additionaljvmargs="${symbol_dollar}{remote.debug.jvmargs} -agentlib:jdwp=transport=dt_socket,server=y,suspend=${symbol_dollar}{remote.debug.suspend},address=${symbol_dollar}{target.platform.host}:${symbol_dollar}{target.debug.port}"/>
+            </sequential>
+        </sshsession>
+    </target>
+    
+    <target name="build-remote" depends="-copy-remote-passwd, -copy-remote-key">
+        
+    </target>
+    
+    <target name="run-remote" depends="-run-remote-passwd, -run-remote-key">
+        
+    </target>
+
+    <target name="clean-remote" depends="-clean-remote-passwd, -clean-remote-key">
+        
+    </target>
+
+    <target name="debug-remote" depends="-debug-remote-passwd, -debug-remote-key">
+        
+    </target>
 
 </project>

--- a/src/main/resources/archetype-resources/nbactions-template.xml
+++ b/src/main/resources/archetype-resources/nbactions-template.xml
@@ -3,20 +3,20 @@
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
 <actions>
-	<action>
-		<actionName>CUSTOM-Remote run</actionName>
-		<displayName>Remote run</displayName>
-		<goals>
-			<goal>install</goal>
-			<goal>antrun:run@exec</goal>
-		</goals>
-	</action>
-	<action>
-		<actionName>CUSTOM-Remote debug</actionName>
-		<displayName>Remote debug</displayName>
-		<goals>
-			<goal>install</goal>
-			<goal>antrun:run@debug</goal>
-		</goals>
-	</action>
+    <action>
+        <actionName>CUSTOM-Remote run</actionName>
+        <displayName>Remote run</displayName>
+        <goals>
+            <goal>install</goal>
+            <goal>antrun:run@exec</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Remote debug</actionName>
+        <displayName>Remote debug</displayName>
+        <goals>
+            <goal>install</goal>
+            <goal>antrun:run@debug</goal>
+        </goals>
+    </action>
 </actions>

--- a/src/main/resources/archetype-resources/platform/raspberry.properties
+++ b/src/main/resources/archetype-resources/platform/raspberry.properties
@@ -21,3 +21,4 @@ target.debug.port=1955
 target.run.as.root=true
 ${symbol_pound} The remote target root folder where your projects is deployed
 target.remote.home=/home/pi/NetBeansProjects
+target.run.module.class=${groupId}.${artifactId}/${package}.${main-class}

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,242 +1,242 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>${groupId}</groupId>
-	<artifactId>${artifactId}</artifactId>
-	<version>${version}</version>
-	<packaging>jar</packaging>
-	<name>${project-name}</name>
-	<!--organization>
-		<name></name>
-		<url></url>
-	</organization-->
-	
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-		<target.platform.name>raspberry</target.platform.name>
-		<run.with.java.module>${useJavaPlatformModuleSystem}</run.with.java.module>
-<!--		Use jvmargs to pass args like -Dpi4j.library.path=<Path to the libpi4j-pigpio.so library>-->
-		<jvmargs.run></jvmargs.run>
-		<jvmargs.debug></jvmargs.debug>
-		
-		<slf4j.version>2.0.0-alpha1</slf4j.version>
-		<pi4j.version>2.0-SNAPSHOT</pi4j.version>
-	</properties>
-	
-	<repositories>
-		<repository>
-			<id>oss-snapshots-repo</id>
-			<name>Sonatype OSS Maven Repository</name>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-			<releases>
-			</releases>
-			<snapshots>
-			</snapshots>
-		</repository>
-	</repositories>
-		
-	<dependencies>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>jar</packaging>
+    <name>${project-name}</name>
+    <!--organization>
+        <name></name>
+        <url></url>
+    </organization-->
+    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <target.platform.name>raspberry</target.platform.name>
+        <run.with.java.module>${useJavaPlatformModuleSystem}</run.with.java.module>
+<!--        Use jvmargs to pass args like -Dpi4j.library.path=<Path to the libpi4j-pigpio.so library>-->
+        <jvmargs.run></jvmargs.run>
+        <jvmargs.debug></jvmargs.debug>
+        
+        <slf4j.version>2.0.0-alpha1</slf4j.version>
+        <pi4j.version>2.0-SNAPSHOT</pi4j.version>
+    </properties>
+    
+    <repositories>
+        <repository>
+            <id>oss-snapshots-repo</id>
+            <name>Sonatype OSS Maven Repository</name>
+            <url>https://oss.sonatype.org/content/groups/public</url>
+            <releases>
+            </releases>
+            <snapshots>
+            </snapshots>
+        </repository>
+    </repositories>
+        
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
-		<!-- include Pi4J Core -->
-		<dependency>
-			<groupId>com.pi4j</groupId>
-			<artifactId>pi4j-core</artifactId>
-			<version>${pi4j.version}</version>
-		</dependency>
+        <!-- include Pi4J Core -->
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-core</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
 
-		<!-- include Pi4J Plugins (Platforms and I/O Providers) -->
-		<dependency>
-			<groupId>com.pi4j</groupId>
-			<artifactId>pi4j-plugin-raspberrypi</artifactId>
-			<version>${pi4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.pi4j</groupId>
-			<artifactId>pi4j-plugin-pigpio</artifactId>
-			<version>${pi4j.version}</version>
-		</dependency>
-	</dependencies>
-		
-	<build>
-		<finalName>${project.artifactId}</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<release>${maven.compiler.source}</release>
-					<target>${maven.compiler.target}</target>
-					<showDeprecation>true</showDeprecation>
-					<showWarnings>true</showWarnings>
-					<verbose>false</verbose>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.1.2</version>
-				<executions>
-					<execution>
-						<id>copy-dependencies</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
-						<configuration>
-							<stripVersion>true</stripVersion>
-							<outputDirectory>${project.build.directory}/lib</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.2.0</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<classpathLayoutType>custom</classpathLayoutType>
-							<customClasspathLayout>lib/${artifact.artifactId}.${artifact.extension}</customClasspathLayout>
-							<mainClass>${package}.${main-class}</mainClass>
-						</manifest>
-					</archive>
-					<outputDirectory>${finalJarDir}</outputDirectory>
-				</configuration>
-			</plugin>
-			<!--plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.3.0</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<archive>
-								<manifest>
-									<addDefaultImplementationEntries/>
-									<mainClass>it.lb.rasp.rasp01.Rasp01</mainClass>
-								</manifest>
-							</archive>
-							<descriptorRefs>
-								<descriptorRef>jar-with-dependencies</descriptorRef>
-							</descriptorRefs>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin-->
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<id>setMavenJarPluginOutputDir</id>
-						<phase>compile</phase>
-						<configuration>
-							<exportAntProperties>true</exportAntProperties>
-							<target>
-								<condition property="finalJarDir" value="${project.build.directory}/lib" else="${project.build.directory}">
-									<equals arg1="${run.with.java.module}" arg2="true" casesensitive="" />
-								</condition>
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>clean</id>
-						<phase>clean</phase>
-						<configuration>
-							<target>
-								<property name="local.dist.dir" value="${project.build.directory}" />		
-								<property name="remote.runtime.encoding" value="UTF-8" />
-								<property name="dist.jar.name" value="${project.build.finalName}" />		
-								<ant antfile="antrun/build.xml" target="clean-remote" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>build</id>
-						<phase>install</phase>
-						<configuration>
-							<target>
-								<property name="local.dist.dir" value="${project.build.directory}" />		
-								<property name="remote.runtime.encoding" value="UTF-8" />
-								<property name="dist.jar.name" value="${project.build.finalName}" />		
-								<ant antfile="antrun/build.xml" target="build-remote" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>exec</id>
-						<configuration>
-							<target>
-								<property name="remote.run.jvmargs" value="${jvmargs.run}" />
-								<property name="target.run.as.module" value="${run.with.java.module}" />
-								<property name="local.dist.dir" value="${project.build.directory}" />		
-								<property name="remote.runtime.encoding" value="UTF-8" />
-								<property name="dist.jar.name" value="${project.build.finalName}" />		
-								<ant antfile="antrun/build.xml" target="run-remote" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>debug</id>
-						<configuration>
-							<target>
-								<property name="remote.debug.jvmargs" value="${jvmargs.debug}" />
-								<property name="target.run.as.module" value="${run.with.java.module}" />
-								<property name="local.dist.dir" value="${project.build.directory}" />		
-								<property name="remote.runtime.encoding" value="UTF-8" />
-								<property name="dist.jar.name" value="${project.build.finalName}" />		
-								<ant antfile="antrun/build.xml" target="debug-remote" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>com.jcraft</groupId>
-						<artifactId>jsch</artifactId>
-						<version>0.1.55</version>
-					</dependency>
-					<dependency>
-						<groupId>org.apache.ant</groupId>
-						<artifactId>ant-jsch</artifactId>
-						<version>1.10.8</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-		</plugins>
-	</build>
+        <!-- include Pi4J Plugins (Platforms and I/O Providers) -->
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-raspberrypi</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-pigpio</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
+    </dependencies>
+        
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>${maven.compiler.source}</release>
+                    <target>${maven.compiler.target}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathLayoutType>custom</classpathLayoutType>
+                            <customClasspathLayout>lib/${artifact.artifactId}.${artifact.extension}</customClasspathLayout>
+                            <mainClass>${package}.${main-class}</mainClass>
+                        </manifest>
+                    </archive>
+                    <outputDirectory>${finalJarDir}</outputDirectory>
+                </configuration>
+            </plugin>
+            <!--plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries/>
+                                    <mainClass>it.lb.rasp.rasp01.Rasp01</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin-->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>setMavenJarPluginOutputDir</id>
+                        <phase>compile</phase>
+                        <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target>
+                                <condition property="finalJarDir" value="${project.build.directory}/lib" else="${project.build.directory}">
+                                    <equals arg1="${run.with.java.module}" arg2="true" casesensitive="" />
+                                </condition>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>clean</id>
+                        <phase>clean</phase>
+                        <configuration>
+                            <target>
+                                <property name="local.dist.dir" value="${project.build.directory}" />        
+                                <property name="remote.runtime.encoding" value="UTF-8" />
+                                <property name="dist.jar.name" value="${project.build.finalName}" />        
+                                <ant antfile="antrun/build.xml" target="clean-remote" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>build</id>
+                        <phase>install</phase>
+                        <configuration>
+                            <target>
+                                <property name="local.dist.dir" value="${project.build.directory}" />        
+                                <property name="remote.runtime.encoding" value="UTF-8" />
+                                <property name="dist.jar.name" value="${project.build.finalName}" />        
+                                <ant antfile="antrun/build.xml" target="build-remote" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>exec</id>
+                        <configuration>
+                            <target>
+                                <property name="remote.run.jvmargs" value="${jvmargs.run}" />
+                                <property name="target.run.as.module" value="${run.with.java.module}" />
+                                <property name="local.dist.dir" value="${project.build.directory}" />        
+                                <property name="remote.runtime.encoding" value="UTF-8" />
+                                <property name="dist.jar.name" value="${project.build.finalName}" />        
+                                <ant antfile="antrun/build.xml" target="run-remote" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>debug</id>
+                        <configuration>
+                            <target>
+                                <property name="remote.debug.jvmargs" value="${jvmargs.debug}" />
+                                <property name="target.run.as.module" value="${run.with.java.module}" />
+                                <property name="local.dist.dir" value="${project.build.directory}" />        
+                                <property name="remote.runtime.encoding" value="UTF-8" />
+                                <property name="dist.jar.name" value="${project.build.finalName}" />        
+                                <ant antfile="antrun/build.xml" target="debug-remote" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.jcraft</groupId>
+                        <artifactId>jsch</artifactId>
+                        <version>0.1.55</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.ant</groupId>
+                        <artifactId>ant-jsch</artifactId>
+                        <version>1.10.8</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -16,6 +16,10 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<target.platform.name>raspberry</target.platform.name>
+		<run.with.java.module>${useJavaPlatformModuleSystem}</run.with.java.module>
+<!--		Use jvmargs to pass args like -Dpi4j.library.path=<Path to the libpi4j-pigpio.so library>-->
+		<jvmargs.run></jvmargs.run>
+		<jvmargs.debug></jvmargs.debug>
 		
 		<slf4j.version>2.0.0-alpha1</slf4j.version>
 		<pi4j.version>2.0-SNAPSHOT</pi4j.version>
@@ -70,6 +74,18 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<release>${maven.compiler.source}</release>
+					<target>${maven.compiler.target}</target>
+					<showDeprecation>true</showDeprecation>
+					<showWarnings>true</showWarnings>
+					<verbose>false</verbose>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>3.1.2</version>
 				<executions>
@@ -92,13 +108,14 @@
 				<version>3.2.0</version>
 				<configuration>
 					<archive>
-								<manifest>																														
+						<manifest>
 							<addClasspath>true</addClasspath>
 							<classpathLayoutType>custom</classpathLayoutType>
 							<customClasspathLayout>lib/${artifact.artifactId}.${artifact.extension}</customClasspathLayout>
 							<mainClass>${package}.${main-class}</mainClass>
 						</manifest>
 					</archive>
+					<outputDirectory>${finalJarDir}</outputDirectory>
 				</configuration>
 			</plugin>
 			<!--plugin>
@@ -129,6 +146,21 @@
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>3.0.0</version>
 				<executions>
+					<execution>
+						<id>setMavenJarPluginOutputDir</id>
+						<phase>compile</phase>
+						<configuration>
+							<exportAntProperties>true</exportAntProperties>
+							<target>
+								<condition property="finalJarDir" value="${project.build.directory}/lib" else="${project.build.directory}">
+									<equals arg1="${run.with.java.module}" arg2="true" casesensitive="" />
+								</condition>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
 					<execution>
 						<id>clean</id>
 						<phase>clean</phase>
@@ -163,6 +195,8 @@
 						<id>exec</id>
 						<configuration>
 							<target>
+								<property name="remote.run.jvmargs" value="${jvmargs.run}" />
+								<property name="target.run.as.module" value="${run.with.java.module}" />
 								<property name="local.dist.dir" value="${project.build.directory}" />		
 								<property name="remote.runtime.encoding" value="UTF-8" />
 								<property name="dist.jar.name" value="${project.build.finalName}" />		
@@ -177,6 +211,8 @@
 						<id>debug</id>
 						<configuration>
 							<target>
+								<property name="remote.debug.jvmargs" value="${jvmargs.debug}" />
+								<property name="target.run.as.module" value="${run.with.java.module}" />
 								<property name="local.dist.dir" value="${project.build.directory}" />		
 								<property name="remote.runtime.encoding" value="UTF-8" />
 								<property name="dist.jar.name" value="${project.build.finalName}" />		

--- a/src/main/resources/archetype-resources/src/main/java/__main-class__.java
+++ b/src/main/resources/archetype-resources/src/main/java/__main-class__.java
@@ -22,59 +22,59 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class ${main-class} {
 
-	private static final int PIN_LED = 22; // PIN 15 = BCM 22
-	private static final Console console = new Console();
+    private static final int PIN_LED = 22; // PIN 15 = BCM 22
+    private static final Console console = new Console();
 
-	/**
-	 * @param args the command line arguments
-	 */
-	public static void main(String[] args) throws Exception {
-		console.box("Hello Rasbian world !");
-		Context pi4j = null;
-		try {
-			pi4j = Pi4J.newAutoContext();
-			new ${main-class}().run(pi4j);
-		} catch (InvocationTargetException e) {
-			console.println("Error: " + e.getTargetException().getMessage());
-		} catch (Exception e) {
-			console.println("Error: " + e.getMessage());
-			e.printStackTrace();
-		} finally {
-			if (pi4j != null) {
-				pi4j.shutdown();
-			}
-		}
-	}
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String[] args) throws Exception {
+        console.box("Hello Rasbian world !");
+        Context pi4j = null;
+        try {
+            pi4j = Pi4J.newAutoContext();
+            new ${main-class}().run(pi4j);
+        } catch (InvocationTargetException e) {
+            console.println("Error: " + e.getTargetException().getMessage());
+        } catch (Exception e) {
+            console.println("Error: " + e.getMessage());
+            e.printStackTrace();
+        } finally {
+            if (pi4j != null) {
+                pi4j.shutdown();
+            }
+        }
+    }
 
-	private void run(Context pi4j) throws Exception {
-		Platforms platforms = pi4j.platforms();
+    private void run(Context pi4j) throws Exception {
+        Platforms platforms = pi4j.platforms();
 
-		console.box("Pi4J PLATFORMS");
-		console.println();
-		platforms.describe().print(System.out);
-		console.println();
+        console.box("Pi4J PLATFORMS");
+        console.println();
+        platforms.describe().print(System.out);
+        console.println();
 
-		var ledConfig = DigitalOutput.newConfigBuilder(pi4j)
-						.id("led")
-						.name("LED Flasher")
-						.address(PIN_LED)
-						.shutdown(DigitalState.LOW)
-						.initial(DigitalState.LOW)
-						.provider("pigpio-digital-output");
+        var ledConfig = DigitalOutput.newConfigBuilder(pi4j)
+                        .id("led")
+                        .name("LED Flasher")
+                        .address(PIN_LED)
+                        .shutdown(DigitalState.LOW)
+                        .initial(DigitalState.LOW)
+                        .provider("pigpio-digital-output");
 
-		var led = pi4j.create(ledConfig);
-		int counter = 0;
-		while (counter < 50) {
-			if (led.equals(DigitalState.HIGH)) {
-				led.low();
-				System.out.println("low");
-			} else {
-				led.high();
-				System.out.println("high");
-			}
-			Thread.sleep(500);
-			counter++;
-		}
-	}
+        var led = pi4j.create(ledConfig);
+        int counter = 0;
+        while (counter < 50) {
+            if (led.equals(DigitalState.HIGH)) {
+                led.low();
+                System.out.println("low");
+            } else {
+                led.high();
+                System.out.println("high");
+            }
+            Thread.sleep(500);
+            counter++;
+        }
+    }
 
 }

--- a/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -1,0 +1,16 @@
+module ${groupId}.${artifactId} {
+    requires org.slf4j;             //slf4j-api-2.0.0-alpha1.jar
+    requires org.slf4j.simple;      //slf4j-simple-2.0.0-alpha1.jar & simplelogger.properties
+    requires com.pi4j;
+    requires com.pi4j.plugin.raspberrypi;
+    requires com.pi4j.plugin.pigpio;
+    requires com.pi4j.library.pigpio;
+
+    uses com.pi4j.extension.Extension;
+    uses com.pi4j.provider.Provider;
+
+    // allow access to classes in the following namespaces for Pi4J annotation processing
+    opens {package} to com.pi4j;
+
+    //exports ${package};
+}

--- a/src/main/resources/archetype-resources/src/main/java/module-info.java
+++ b/src/main/resources/archetype-resources/src/main/java/module-info.java
@@ -10,7 +10,7 @@ module ${groupId}.${artifactId} {
     uses com.pi4j.provider.Provider;
 
     // allow access to classes in the following namespaces for Pi4J annotation processing
-    opens {package} to com.pi4j;
+    opens ${package} to com.pi4j;
 
     //exports ${package};
 }

--- a/src/main/resources/archetype-resources/src/main/resources/simplelogger.properties
+++ b/src/main/resources/archetype-resources/src/main/resources/simplelogger.properties
@@ -1,0 +1,41 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+#The output target which can be the path to a file, or the special values "System.out" and "System.err". Default is "System.err".
+org.slf4j.simpleLogger.logFile=System.out
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=debug
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+#org.slf4j.simpleLogger.log.freemarker=debug
+#org.slf4j.simpleLogger.log.ro.pippo=debug
+#org.slf4j.simpleLogger.log.ro.fortsoft.matilda=debug
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+#org.slf4j.simpleLogger.showDateTime=false
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -5,3 +5,4 @@ artifactId=basic
 version=0.1-SNAPSHOT
 project-name=My Project
 main-class=main
+useJavaPlatformModuleSystem=true


### PR DESCRIPTION
Following up on issue #1. Here is a working concept of how the archetype would handle the module-info.

TODO:
- [x] write the `archetype-post-generate.groovy` [file](https://maven.apache.org/archetype/maven-archetype-plugin/advanced-usage.html) to delete the `module-info.java` if the user property `useJavaPlatformModuleSystem=false` - the pom.xml does not need to be changed;
- [ ] update README.md with how the new parameters (`useJavaPlatformModuleSystem`, `run.with.java.module` and `target.run.module.class`) work;

The current PR is a working JPMS project, so feel free to test it and provide feedback!